### PR TITLE
[REFACTOR] Renaming "moderation" group to "mod"

### DIFF
--- a/src/main/java/de/nplay/moderationbot/moderation/commands/BulkDeleteCommands.java
+++ b/src/main/java/de/nplay/moderationbot/moderation/commands/BulkDeleteCommands.java
@@ -1,11 +1,11 @@
 package de.nplay.moderationbot.moderation.commands;
 
-import com.google.inject.Inject;
 import com.github.kaktushose.jda.commands.annotations.constraints.Max;
 import com.github.kaktushose.jda.commands.annotations.constraints.Min;
 import com.github.kaktushose.jda.commands.annotations.interactions.*;
 import com.github.kaktushose.jda.commands.dispatching.events.interactions.CommandEvent;
 import com.github.kaktushose.jda.commands.embeds.EmbedCache;
+import com.google.inject.Inject;
 import de.nplay.moderationbot.embeds.EmbedHelpers;
 import de.nplay.moderationbot.permissions.BotPermissions;
 import de.nplay.moderationbot.serverlog.ModerationEvents;
@@ -32,7 +32,7 @@ public class BulkDeleteCommands {
     @Inject
     private Serverlog serverlog;
 
-    @Command(value = "moderation purge messages", desc = "Löscht eine bestimmte Anzahl an Nachrichten gleichzeitig")
+    @Command(value = "mod purge messages", desc = "Löscht eine bestimmte Anzahl an Nachrichten gleichzeitig")
     public void purgeMessagesByAmount(CommandEvent event, @Param("Anzahl der Nachrichten die gelöscht werden sollen") @Min(1) @Max(100) int amount) {
         var deletedMessages = purgeMessages(event, event.getMessageChannel(), event.getMessageChannel().getLatestMessageId(), amount) - 1;
         replyEvent(event, deletedMessages);

--- a/src/main/java/de/nplay/moderationbot/moderation/commands/DeleteCommand.java
+++ b/src/main/java/de/nplay/moderationbot/moderation/commands/DeleteCommand.java
@@ -1,13 +1,13 @@
 package de.nplay.moderationbot.moderation.commands;
 
 import com.github.kaktushose.jda.commands.annotations.interactions.*;
-import com.google.inject.Inject;
 import com.github.kaktushose.jda.commands.dispatching.events.interactions.CommandEvent;
 import com.github.kaktushose.jda.commands.embeds.EmbedCache;
+import com.google.inject.Inject;
 import de.nplay.moderationbot.embeds.EmbedColors;
 import de.nplay.moderationbot.moderation.ModerationService;
-import de.nplay.moderationbot.serverlog.ModerationEvents;
 import de.nplay.moderationbot.permissions.BotPermissions;
+import de.nplay.moderationbot.serverlog.ModerationEvents;
 import de.nplay.moderationbot.serverlog.Serverlog;
 import net.dv8tion.jda.api.Permission;
 import org.slf4j.Logger;
@@ -25,7 +25,7 @@ public class DeleteCommand {
     private Serverlog serverlog;
 
     @CommandConfig(enabledFor = Permission.BAN_MEMBERS)
-    @Command(value = "moderation delete", desc = "Löscht eine Moderationshandlung")
+    @Command(value = "mod delete", desc = "Löscht eine Moderationshandlung")
     @Permissions(BotPermissions.MODERATION_DELETE)
     public void deleteModeration(CommandEvent event, @Param("Die ID der Moderationshandlung, die gelöscht werden soll") long moderationId) {
         var moderation = ModerationService.getModerationAct(moderationId);

--- a/src/main/java/de/nplay/moderationbot/moderation/commands/DetailCommand.java
+++ b/src/main/java/de/nplay/moderationbot/moderation/commands/DetailCommand.java
@@ -1,9 +1,12 @@
 package de.nplay.moderationbot.moderation.commands;
 
-import com.github.kaktushose.jda.commands.annotations.interactions.*;
-import com.google.inject.Inject;
+import com.github.kaktushose.jda.commands.annotations.interactions.Command;
+import com.github.kaktushose.jda.commands.annotations.interactions.Interaction;
+import com.github.kaktushose.jda.commands.annotations.interactions.Param;
+import com.github.kaktushose.jda.commands.annotations.interactions.Permissions;
 import com.github.kaktushose.jda.commands.dispatching.events.interactions.CommandEvent;
 import com.github.kaktushose.jda.commands.embeds.EmbedCache;
+import com.google.inject.Inject;
 import de.nplay.moderationbot.embeds.EmbedColors;
 import de.nplay.moderationbot.moderation.ModerationService;
 import de.nplay.moderationbot.permissions.BotPermissions;
@@ -14,7 +17,7 @@ public class DetailCommand {
     @Inject
     private EmbedCache embedCache;
 
-    @Command(value = "moderation detail", desc = "Zeigt mehr Informationen zu einer Moderationshandlung an")
+    @Command(value = "mod detail", desc = "Zeigt mehr Informationen zu einer Moderationshandlung an")
     @Permissions(BotPermissions.MODERATION_READ)
     public void detail(CommandEvent event, @Param("Die ID der Moderationshandlung") Long moderationId) {
         var moderationAct = ModerationService.getModerationAct(moderationId);

--- a/src/main/java/de/nplay/moderationbot/moderation/create/ModerationCommands.java
+++ b/src/main/java/de/nplay/moderationbot/moderation/create/ModerationCommands.java
@@ -44,7 +44,7 @@ public class ModerationCommands {
     private static final String PARAGRAPH_PARAMETER_DESC = "Welcher Regel-Paragraph ist verletzt worden / soll referenziert werden?";
     private ModerationActType type;
 
-    @AutoComplete(value = {"moderation", "spielersuche ausschluss"}, options = "paragraph")
+    @AutoComplete(value = {"mod", "spielersuche ausschluss"}, options = "paragraph")
     public void onParagraphAutocomplete(AutoCompleteEvent event) {
         var rules = RuleService.getParagraphIdMapping();
         rules.values().removeIf(it -> !it.shortDisplay().toLowerCase().contains(event.getValue().toLowerCase()));
@@ -56,7 +56,7 @@ public class ModerationCommands {
         );
     }
 
-    @Command(value = "moderation warn", desc = "Verwarnt einen Benutzer")
+    @Command(value = "mod warn", desc = "Verwarnt einen Benutzer")
     public void warnMember(CommandEvent event,
                            @Param("Der Benutzer, der verwarnt werden soll.") Member target,
                            @Optional @Param(PARAGRAPH_PARAMETER_DESC) String paragraph) {
@@ -81,7 +81,7 @@ public class ModerationCommands {
         event.replyModal("onModerate", modal -> modal.title("Begründung angeben (Warn)"));
     }
 
-    @Command(value = "moderation timeout", desc = "Versetzt einen Benutzer in den Timeout")
+    @Command(value = "mod timeout", desc = "Versetzt einen Benutzer in den Timeout")
     public void timeoutMember(CommandEvent event,
                               @Param("Der Benutzer, den in den Timeout versetzt werden soll.") Member target,
                               @Param("Für wie lange der Timeout andauern soll (max. 28 Tage)") @DurationMax(2419200)
@@ -109,7 +109,7 @@ public class ModerationCommands {
     }
 
     @CommandConfig(enabledFor = Permission.KICK_MEMBERS)
-    @Command(value = "moderation kick", desc = "Kickt einen Benutzer vom Server")
+    @Command(value = "mod kick", desc = "Kickt einen Benutzer vom Server")
     public void kickMember(CommandEvent event,
                            @Param("Der Benutzer, der gekickt werden soll.") Member target,
                            @Optional @Param(PARAGRAPH_PARAMETER_DESC) String paragraph,
@@ -140,7 +140,7 @@ public class ModerationCommands {
     }
 
     @CommandConfig(enabledFor = Permission.BAN_MEMBERS)
-    @Command(value = "moderation ban", desc = "Bannt einen Benutzer vom Server")
+    @Command(value = "mod ban", desc = "Bannt einen Benutzer vom Server")
     public void banMember(
             CommandEvent event,
             @Param("Der Benutzer, der gekickt werden soll.") Member target,

--- a/src/main/java/de/nplay/moderationbot/moderation/modlog/ModlogCommand.java
+++ b/src/main/java/de/nplay/moderationbot/moderation/modlog/ModlogCommand.java
@@ -47,7 +47,7 @@ public class ModlogCommand {
 
     public record ModlogContext(@NotNull User user, @Nullable Member member) {}
 
-    @Command(value = "moderation modlog", desc = "Zeigt den Modlog eines Mitglieds an")
+    @Command(value = "mod log", desc = "Zeigt den Modlog eines Mitglieds an")
     public void modlog(CommandEvent event, @Param("Der User, dessen Modlog abgerufen werden soll")
                        User user,
                        @Optional @Param("Die Seite, die angezeigt werden soll") @Min(1) Integer page,

--- a/src/main/java/de/nplay/moderationbot/moderation/revert/RevertCommand.java
+++ b/src/main/java/de/nplay/moderationbot/moderation/revert/RevertCommand.java
@@ -1,13 +1,13 @@
 package de.nplay.moderationbot.moderation.revert;
 
-import com.google.inject.Inject;
 import com.github.kaktushose.jda.commands.annotations.interactions.*;
 import com.github.kaktushose.jda.commands.dispatching.events.interactions.CommandEvent;
 import com.github.kaktushose.jda.commands.embeds.EmbedCache;
+import com.google.inject.Inject;
 import de.nplay.moderationbot.embeds.EmbedColors;
 import de.nplay.moderationbot.moderation.ModerationService;
-import de.nplay.moderationbot.serverlog.ModerationEvents;
 import de.nplay.moderationbot.permissions.BotPermissions;
+import de.nplay.moderationbot.serverlog.ModerationEvents;
 import de.nplay.moderationbot.serverlog.Serverlog;
 
 @Interaction
@@ -19,7 +19,7 @@ public class RevertCommand {
     @Inject
     private Serverlog serverlog;
 
-    @Command(value = "moderation revert", desc = "Hebt eine Moderationshandlung auf")
+    @Command(value = "mod revert", desc = "Hebt eine Moderationshandlung auf")
     @Permissions(BotPermissions.MODERATION_REVERT)
     public void revertModeration(CommandEvent event, @Param("Die ID der Moderationshandlung, die aufgehoben werden soll") long moderationId,
                                  @Optional @Param(value = "Der Grund für die Aufhebung") String reason) {


### PR DESCRIPTION
fixes #52 

Nach interner Rücksprache soll die moderation command group in mod umbenannt werden, um kollisionen mit carl zu vermeiden 