### PR TITLE
[FEAT] Added option to provide a message link in slash moderation command

### DIFF
--- a/src/main/java/de/nplay/moderationbot/messagelink/MessageLink.java
+++ b/src/main/java/de/nplay/moderationbot/messagelink/MessageLink.java
@@ -1,0 +1,58 @@
+package de.nplay.moderationbot.messagelink;
+
+public class MessageLink {
+
+    private final String messageId;
+    private final String channelId;
+    private final String guildId;
+
+    public MessageLink(String messageId, String channelId, String guildId) {
+        this.messageId = messageId;
+        this.channelId = channelId;
+        this.guildId = guildId;
+    }
+
+    /**
+     * Creates a {@link MessageLink} from a discord message link.
+     *
+     * @param link The message link to parse. The link should be in the format: <br />
+     *             <code>https://discord.com/channels/{guildId}/{channelId}/{messageId}</code>
+     * @return A {@link MessageLink} object containing the messageId, channelId and guildId
+     * @throws IllegalArgumentException if the link is not valid
+     */
+    public static MessageLink fromLink(String link) {
+        if (!validateLink(link)) {
+            throw new IllegalArgumentException("Invalid message link: " + link);
+        }
+        String[] parts = link.split("/");
+        return new MessageLink(parts[6], parts[5], parts[4]);
+    }
+
+    /**
+     * Validates a discord message link. The link should be in the format: <br />
+     * <code>https://discord.com/channels/{guildId}/{channelId}/{messageId}</code>
+     *
+     * @param link The message link to validate
+     * @return true if the link is valid, false otherwise
+     */
+    public static boolean validateLink(String link) {
+        return link.matches("https://discord.com/channels/\\d+/\\d+/\\d+");
+    }
+
+    public String getDiscordLink() {
+        return "https://discord.com/channels/%s/%s/%s".formatted(guildId, channelId, messageId);
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public String getChannelId() {
+        return channelId;
+    }
+
+    public String getGuildId() {
+        return guildId;
+    }
+
+}

--- a/src/main/java/de/nplay/moderationbot/messagelink/MessageLink.java
+++ b/src/main/java/de/nplay/moderationbot/messagelink/MessageLink.java
@@ -20,7 +20,7 @@ public class MessageLink {
      * @return A {@link MessageLink} object containing the messageId, channelId and guildId
      * @throws IllegalArgumentException if the link is not valid
      */
-    public static MessageLink fromLink(String link) {
+    public static MessageLink ofString(String link) {
         if (!validateLink(link)) {
             throw new IllegalArgumentException("Invalid message link: " + link);
         }

--- a/src/main/java/de/nplay/moderationbot/messagelink/MessageLink.java
+++ b/src/main/java/de/nplay/moderationbot/messagelink/MessageLink.java
@@ -1,16 +1,8 @@
 package de.nplay.moderationbot.messagelink;
 
-public class MessageLink {
+import java.util.Optional;
 
-    private final String messageId;
-    private final String channelId;
-    private final String guildId;
-
-    public MessageLink(String messageId, String channelId, String guildId) {
-        this.messageId = messageId;
-        this.channelId = channelId;
-        this.guildId = guildId;
-    }
+public record MessageLink(String messageId, String channelId, String guildId) {
 
     /**
      * Creates a {@link MessageLink} from a discord message link.
@@ -20,39 +12,18 @@ public class MessageLink {
      * @return A {@link MessageLink} object containing the messageId, channelId and guildId
      * @throws IllegalArgumentException if the link is not valid
      */
-    public static MessageLink ofString(String link) {
-        if (!validateLink(link)) {
-            throw new IllegalArgumentException("Invalid message link: " + link);
-        }
+    public static Optional<MessageLink> ofString(String link) {
+        if (!validateLink(link)) return Optional.empty();
         String[] parts = link.split("/");
-        return new MessageLink(parts[6], parts[5], parts[4]);
+        return Optional.of(new MessageLink(parts[6], parts[5], parts[4]));
     }
 
-    /**
-     * Validates a discord message link. The link should be in the format: <br />
-     * <code>https://discord.com/channels/{guildId}/{channelId}/{messageId}</code>
-     *
-     * @param link The message link to validate
-     * @return true if the link is valid, false otherwise
-     */
-    public static boolean validateLink(String link) {
+    private static boolean validateLink(String link) {
         return link.matches("https://discord.com/channels/\\d+/\\d+/\\d+");
     }
 
-    public String getDiscordLink() {
+    public String discordLink() {
         return "https://discord.com/channels/%s/%s/%s".formatted(guildId, channelId, messageId);
-    }
-
-    public String getMessageId() {
-        return messageId;
-    }
-
-    public String getChannelId() {
-        return channelId;
-    }
-
-    public String getGuildId() {
-        return guildId;
     }
 
 }

--- a/src/main/java/de/nplay/moderationbot/messagelink/MessageLinkAdapter.java
+++ b/src/main/java/de/nplay/moderationbot/messagelink/MessageLinkAdapter.java
@@ -14,7 +14,7 @@ public class MessageLinkAdapter implements TypeAdapter<MessageLink> {
     @NotNull
     public Optional<MessageLink> apply(@NotNull String raw, @NotNull GenericInteractionCreateEvent event) {
         try {
-            return Optional.of(MessageLink.fromLink(raw));
+            return Optional.of(MessageLink.ofString(raw));
         } catch (IllegalArgumentException e) {
             return Optional.empty();
         }

--- a/src/main/java/de/nplay/moderationbot/messagelink/MessageLinkAdapter.java
+++ b/src/main/java/de/nplay/moderationbot/messagelink/MessageLinkAdapter.java
@@ -1,0 +1,23 @@
+package de.nplay.moderationbot.messagelink;
+
+import com.github.kaktushose.jda.commands.dispatching.adapter.TypeAdapter;
+import com.github.kaktushose.jda.commands.guice.Implementation;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+
+@Implementation(clazz = MessageLink.class)
+public class MessageLinkAdapter implements TypeAdapter<MessageLink> {
+
+    @Override
+    @NotNull
+    public Optional<MessageLink> apply(@NotNull String raw, @NotNull GenericInteractionCreateEvent event) {
+        try {
+            return Optional.of(MessageLink.fromLink(raw));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/src/main/java/de/nplay/moderationbot/messagelink/MessageLinkAdapter.java
+++ b/src/main/java/de/nplay/moderationbot/messagelink/MessageLinkAdapter.java
@@ -13,11 +13,7 @@ public class MessageLinkAdapter implements TypeAdapter<MessageLink> {
     @Override
     @NotNull
     public Optional<MessageLink> apply(@NotNull String raw, @NotNull GenericInteractionCreateEvent event) {
-        try {
-            return Optional.of(MessageLink.ofString(raw));
-        } catch (IllegalArgumentException e) {
-            return Optional.empty();
-        }
+        return MessageLink.ofString(raw);
     }
 
 }

--- a/src/main/java/de/nplay/moderationbot/moderation/create/ModerationCommands.java
+++ b/src/main/java/de/nplay/moderationbot/moderation/create/ModerationCommands.java
@@ -134,8 +134,7 @@ public class ModerationCommands {
                            @Param("Der Benutzer, der gekickt werden soll.") Member target,
                            @Optional @Param(PARAGRAPH_PARAMETER_DESC) String paragraph,
                            @Optional @Max(7)
-                           @Param("Für wie viele Tage in der Vergangenheit sollen Nachrichten dieses Users gelöscht werden?")
-                               int delDays,
+                           @Param("Für wie viele Tage in der Vergangenheit sollen Nachrichten dieses Users gelöscht werden?") int delDays,
                            @Optional @Param(MESSAGELINK_PARAMETER_DESC) MessageLink messageLink) {
         if (checkLocked(event, target, event.getUser())) return;
         moderationActBuilder = ModerationActBuilder.kick(target, event.getUser()).paragraph(paragraph).deletionDays(delDays);

--- a/src/main/java/de/nplay/moderationbot/moderation/create/ModerationCommands.java
+++ b/src/main/java/de/nplay/moderationbot/moderation/create/ModerationCommands.java
@@ -303,12 +303,12 @@ public class ModerationCommands {
     private void setMessageReference(ReplyableEvent<?> event, MessageLink messageLink) {
         if (messageLink == null) return;
 
-        var guildChannel = event.getGuild().getGuildChannelById(messageLink.getChannelId());
+        var guildChannel = event.getGuild().getGuildChannelById(messageLink.channelId());
         if (guildChannel == null) return;
 
         if (!(guildChannel instanceof MessageChannel messageChannel)) return;
 
-        var message = messageChannel.retrieveMessageById(messageLink.getMessageId()).complete();
+        var message = messageChannel.retrieveMessageById(messageLink.messageId()).complete();
         if (message == null) return;
 
         moderationActBuilder.messageReference(message);


### PR DESCRIPTION
fixes #51 

Mit diesem PR erhält der Moderator die Option auch bei einem Slash Command mittels Discord Nachrichten Link eine Nachricht in der Moderationshandlung zu referenzieren.