### PR TITLE
[FIX] Support short display as input for paragraph option

### DIFF
--- a/src/main/java/de/nplay/moderationbot/moderation/create/ModerationActBuilder.java
+++ b/src/main/java/de/nplay/moderationbot/moderation/create/ModerationActBuilder.java
@@ -2,6 +2,7 @@ package de.nplay.moderationbot.moderation.create;
 
 import de.nplay.moderationbot.moderation.ModerationActType;
 import de.nplay.moderationbot.moderation.ModerationService;
+import de.nplay.moderationbot.rules.RuleService;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.internal.utils.Checks;
 import org.jetbrains.annotations.NotNull;
@@ -114,7 +115,12 @@ public class ModerationActBuilder {
         if (paragraphId == null) {
             return this;
         }
-        this.paragraphId = Integer.parseInt(paragraphId);
+        try {
+            this.paragraphId = Integer.parseInt(paragraphId);
+        } catch (NumberFormatException e) {
+            this.paragraphId = RuleService.getRuleParagraphByDisplayName(paragraphId).map(RuleService.RuleParagraph::id)
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid paragraph ID or name: " + paragraphId));
+        }
         return this;
     }
 

--- a/src/main/java/de/nplay/moderationbot/rules/RuleService.java
+++ b/src/main/java/de/nplay/moderationbot/rules/RuleService.java
@@ -51,6 +51,19 @@ public class RuleService {
     }
 
     /**
+     * Gets a {@link RuleParagraph} based on its short display name
+     *
+     * @param displayName the short display name of the paragraph
+     * @return an Optional holding the {@link RuleParagraph}
+     */
+    public static Optional<RuleParagraph> getRuleParagraphByDisplayName(@NotNull String displayName) {
+        return getRuleParagraphs()
+                .stream()
+                .filter(r -> r.shortDisplay().equalsIgnoreCase(displayName))
+                .findFirst();
+    }
+
+    /**
      * Gets a mapping of the internal ids and the paragraph number
      *
      * @return a Map containing all internal ids and their corresponding paragraph number


### PR DESCRIPTION
aktuell bug: Man wählt pargraph aus, wechselt kanal, geht wieder zurück, führt command aus -> kaputt
Daher dieser fix