### PR TITLE
Fix: Temp-Ban was’t working properly

### DIFF
--- a/src/main/java/de/nplay/moderationbot/moderation/commands/create/BanCommand.java
+++ b/src/main/java/de/nplay/moderationbot/moderation/commands/create/BanCommand.java
@@ -70,7 +70,9 @@ public class BanCommand {
 
         builder.paragraph(paragraph).messageReference(Helpers.retrieveMessage(event, messageLink));
 
-        if(until != null) builder.duration(until);
+        if (until != null) {
+            builder.duration(until);
+        }
 
         event.keyValueStore().put(BUILDER, builder);
         replyModal(event, until == null ? "Bann" : "Temp-Bann");

--- a/src/main/java/de/nplay/moderationbot/moderation/commands/create/BanCommand.java
+++ b/src/main/java/de/nplay/moderationbot/moderation/commands/create/BanCommand.java
@@ -70,6 +70,8 @@ public class BanCommand {
 
         builder.paragraph(paragraph).messageReference(Helpers.retrieveMessage(event, messageLink));
 
+        if(until != null) builder.duration(until);
+
         event.keyValueStore().put(BUILDER, builder);
         replyModal(event, until == null ? "Bann" : "Temp-Bann");
     }


### PR DESCRIPTION
## Type
- [ ] Feature
- [x] Fix
- [ ] Refactor

closes #83 

## Description

Due to a missing builder call, the until variable (duration) wasn’t handed over to the moderation builder.

## Checklist

- [x] Applied IntelliJ Formatter (`Ctrl` + `Shift` + `L`)
- [x] Applied `gradle format`
- [ ] If applicable, added unit tests
